### PR TITLE
docs: READMEに初回認証の手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,20 @@ docker run -it --rm \
   serena-dev:latest
 ```
 
-### 5. Serena-MCPの初期化
+### 5. 初回認証 (コンテナ内での初回起動時のみ)
+
+開発コンテナに接続した後、以下のコマンドを実行して各AIツールにログインします。
+ブラウザが開き、認証を求められます。
+
+```bash
+# Claude Code
+claude
+
+# Gemini CLI
+gemini
+```
+
+### 6. Serena-MCPの初期化
 
 コンテナ内で以下を実行：
 


### PR DESCRIPTION
README.mdに、ClaudeとGeminiの初回利用時に必要なインタラクティブなログイン手順が記載されていなかったため追加しました。

`PROJECT_SETUP.md`に記載されていた`claude`および`gemini`コマンドの実行による認証プロセスを、メインのセットアップフローに統合しました。 これにより、新規ユーザーが環境構築でつまずく可能性を低減します。

また、`mcp`の初期設定に関する記述が正しいことも確認済みです。