### PR TITLE
fix(env): Ensure serena, claude, and gemini are available in all envi…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,19 @@ services:
     # 起動時のコマンド（ツールのインストールを確実に実行）
     command: |
       bash -c "
+        echo '=== Installing Serena dependencies ===' &&
+        if ! pyenv versions --bare | grep -q '^3.11.9$'; then
+          echo 'Installing Python 3.11.9...' &&
+          pyenv install 3.11.9
+        fi &&
+        if ! $HOME/.pyenv/versions/3.11.9/bin/pip list | grep -q 'serena-agent'; then
+          echo 'Installing Serena Agent...' &&
+          $HOME/.pyenv/versions/3.11.9/bin/pip install git+https://github.com/oraios/serena
+        fi &&
+        if [ ! -L /usr/local/bin/serena ]; then
+          echo 'Creating symlink for serena...' &&
+          ln -s $HOME/.pyenv/versions/3.11.9/bin/serena /usr/local/bin/serena
+        fi &&
         echo '=== Installing missing tools ===' &&
         if ! command -v claude &> /dev/null; then
           echo 'Installing Claude Code...' &&


### PR DESCRIPTION
…ronments

This commit addresses several issues with the development environment setup to ensure the `serena`, `claude`, and `gemini` command-line tools are available and functional.

For the devcontainer (`.devcontainer/devcontainer.json`):
- Removes the invalid `--auto-level` flag from the `serena` startup command, allowing the `serena-mcp` server to start.

For the docker-compose (`docker-compose.yml`) flow:
- Adds a startup step to install Python 3.11.9 using `pyenv`, as it's a required dependency for `serena-agent`.
- Installs the `serena-agent` package using the correct Python version.
- Creates a symbolic link for the `serena` executable in `/usr/local/bin` to make it available in the system `PATH`.

These changes ensure that the development environment is configured correctly and all required tools are available, regardless of whether it is launched via VS Code's dev container feature or with `docker-compose`.