### PR TITLE
Fix dev container build failure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -129,13 +129,8 @@ RUN echo "Pre-loading Serena-MCP..." && \
     (timeout 10 uvx --from git+https://github.com/oraios/serena serena --version || true) && \
     echo "Serena-MCP pre-load complete"
 
-# デフォルト設定ファイルのコピー（ビルドコンテキストはプロジェクトルート）
-# 存在するファイルのみコピー（条件付き）
-COPY .serena/serena_config.y* /tmp/serena-config/ 2>/dev/null || true
-COPY .gemini/settings.json /tmp/gemini-config/ 2>/dev/null || true
-COPY .claude/memory.json /tmp/claude-config/ 2>/dev/null || true
-
 # 設定ファイルを適切な場所に移動（存在する場合のみ）
+# Note: Config files are now copied via postCreateCommand in devcontainer.json
 RUN if [ -d /tmp/serena-config ] && [ "$(ls -A /tmp/serena-config)" ]; then \
         cp /tmp/serena-config/* /root/.serena/ 2>/dev/null || true; \
         rm -rf /tmp/serena-config; \
@@ -153,7 +148,7 @@ RUN if [ -d /tmp/serena-config ] && [ "$(ls -A /tmp/serena-config)" ]; then \
 # ビルド時にはスキップし、postCreateCommandでコピーする
 
 # Makefileのコピー（存在する場合）
-COPY Makefil[e] /workspaces/ 2>/dev/null || true
+# Note: Makefile is now copied via postCreateCommand in devcontainer.json
 
 # エントリーポイントスクリプト
 RUN echo '#!/bin/bash\n\

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,11 +48,13 @@
   
   // プロジェクトセットアップ（作成後）
   "postCreateCommand": {
-    "copy-claude-commands": "if [ -d /workspaces/${localWorkspaceFolderBasename}/.claude/commands ]; then cp -r /workspaces/${localWorkspaceFolderBasename}/.claude/commands/* ~/.claude/commands/ 2>/dev/null || true; fi",
-    "copy-configs": "if [ -f /workspaces/${localWorkspaceFolderBasename}/.claude/memory.json ]; then cp /workspaces/${localWorkspaceFolderBasename}/.claude/memory.json ~/.claude/; fi",
+    "copy-claude-files": "echo 'Copying Claude files...' && if [ -d /workspaces/${localWorkspaceFolderBasename}/.claude/commands ]; then cp -r /workspaces/${localWorkspaceFolderBasename}/.claude/commands/* ~/.claude/commands/; fi && if [ -f /workspaces/${localWorkspaceFolderBasename}/.claude/memory.json ]; then cp /workspaces/${localWorkspaceFolderBasename}/.claude/memory.json ~/.claude/; fi",
+    "copy-gemini-files": "echo 'Copying Gemini files...' && if [ -f /workspaces/${localWorkspaceFolderBasename}/.gemini/settings.json ]; then cp /workspaces/${localWorkspaceFolderBasename}/.gemini/settings.json ~/.gemini/; fi",
+    "copy-serena-files": "echo 'Copying Serena files...' && if [ -f /workspaces/${localWorkspaceFolderBasename}/.serena/serena_config.yml ]; then cp /workspaces/${localWorkspaceFolderBasename}/.serena/serena_config.yml ~/.serena/; elif [ -f /workspaces/${localWorkspaceFolderBasename}/.serena/serena_config.yaml ]; then cp /workspaces/${localWorkspaceFolderBasename}/.serena/serena_config.yaml ~/.serena/; fi",
+    "copy-makefile": "echo 'Copying Makefile...' && if [ -f /workspaces/${localWorkspaceFolderBasename}/Makefile ]; then cp /workspaces/${localWorkspaceFolderBasename}/Makefile /workspaces/; fi",
     "verify-gpu": "nvidia-smi --query-gpu=name,memory.total --format=csv,noheader || echo 'GPU not available'",
     "verify-commands": "echo 'Checking commands...' && (claude --version || echo 'Claude not installed') && (gemini --version || echo 'Gemini not installed')",
-    "setup-project": "if [ -f /workspaces/${localWorkspaceFolderBasename}/Makefile ]; then cd /workspaces/${localWorkspaceFolderBasename} && make setup; else echo 'No Makefile found'; fi",
+    "setup-project": "if [ -f /workspaces/Makefile ]; then cd /workspaces/${localWorkspaceFolderBasename} && make setup; else echo 'No Makefile found'; fi",
     "set-permissions": "chmod -R 755 ~/.serena ~/.gemini ~/.claude ~/PDF"
   },
   


### PR DESCRIPTION
The dev container build was failing due to invalid `COPY` instructions in the `.devcontainer/Dockerfile`. The instructions included shell-style error suppression (`2>/dev/null || true`), which is not valid Dockerfile syntax.

This change removes the problematic `COPY` instructions from the Dockerfile. The logic for copying configuration files and the Makefile is moved to the `postCreateCommand` in `.devcontainer/devcontainer.json`. This ensures the files are copied from the workspace after the container is created, which is a more robust approach that avoids build failures if the files do not exist in the repository.