### PR TITLE
Fix: Remove problematic PDF mount from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -156,8 +156,6 @@
   
   // マウント設定
   "mounts": [
-    // PDFライブラリをマウント（存在する場合のみ）
-    "source=${localEnv:HOME}/PDF,target=/root/PDF,type=bind,consistency=cached",
     // SSH設定（存在する場合のみ）
     "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,readonly"
   ],


### PR DESCRIPTION
The devcontainer build was failing due to an invalid bind mount for a PDF directory. The configuration attempted to mount `${localEnv:HOME}/PDF`, which was resolving to an invalid path `/PDF` on the user's machine, causing the `docker run` command to fail.

The comment in `devcontainer.json` indicated that this mount was optional. This commit removes the PDF mount configuration to allow the dev container to build successfully without this optional, and problematic, mount.