### PR TITLE
fix(devcontainer): Remove manual SSH mount to fix Windows path error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -154,12 +154,6 @@
     "storage": "32gb"
   },
   
-  // マウント設定
-  "mounts": [
-    // SSH設定（存在する場合のみ）
-    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,readonly"
-  ],
-  
   // 待機設定
   "waitFor": "postStartCommand",
   


### PR DESCRIPTION
Removes the hardcoded `mounts` configuration for the `.ssh` directory from `devcontainer.json`.

This manual mount was causing errors on Windows systems where the `${localEnv:HOME}` variable does not resolve to the correct path for the `.ssh` directory, leading to a "bind source path does not exist" error when building the dev container.

By removing this, we now rely on the VS Code Dev Containers extension's default behavior, which automatically and correctly mounts the user's `.ssh` directory across different operating systems (Windows, macOS, and Linux).