### PR TITLE
fix(devcontainer): Remove github-cli feature to prevent build error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -130,7 +130,6 @@
   // 追加機能
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true,
       "installDockerBuildx": true


### PR DESCRIPTION
The dev container was failing to build on Windows hosts due to an error: `bind source path does not exist: /.ssh`.

This error was caused by the VS Code Remote - Containers extension automatically attempting to mount the user's SSH directory into the container. The investigation suggests this behavior was triggered by the `ghcr.io/devcontainers/features/github-cli` feature specified in `devcontainer.json`.

Since the user confirmed that the GitHub CLI is not required for their workflow, this feature has been removed from the configuration. This prevents the problematic SSH mount from being added to the `docker run` command, resolving the build failure at its root cause.