### PR TITLE
fix(devcontainer): Remove git feature to prevent SSH mount error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -129,7 +129,6 @@
   
   // 追加機能
   "features": {
-    "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true,
       "installDockerBuildx": true


### PR DESCRIPTION
Removes the `ghcr.io/devcontainers/features/git` feature from the `devcontainer.json` configuration.

This feature was automatically attempting to mount the user's local SSH keys into the container, causing an error on Windows systems where the default `/.ssh` path does not exist.

Per the user's request, as they do not use SSH, this feature has been removed. The `git` command-line tool remains available in the container as it is installed separately in the project's Dockerfile. This change resolves the container build error without removing necessary tooling.