### PR TITLE
Fixes a dev container build failure by allowing apt-get to modify hel…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ ENV SERENA_AUTO_LEVEL=5
 ENV SERENA_CONTEXT=ide-assistant
 
 # 基本パッケージのインストール
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --allow-change-held-packages \
     # 基本ツール
     curl \
     wget \


### PR DESCRIPTION
…d packages.

The build was failing because it tried to install libnccl2 and libnccl-dev, which were held. Adding the --allow-change-held-packages flag to the apt-get install command resolves this issue.